### PR TITLE
Edit permissions

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -44,6 +44,12 @@
                 "regenerate_help_text": "Regenerates the encryption key for Collabora Online server. Regenerating this key invalidates any existing wopi file preview/edit sessions.",
                 "placeholder": "",
                 "default": null
+            },
+            {
+                "key": "FileEditPermissions",
+                "display_name": "File Edit Permissions:",
+                "type": "bool",
+                "help_text": "If enabled, editing files is restricted to the file owner by default and they have the ability to share access with the whole channel."
             }
         ]
     }

--- a/server/api.go
+++ b/server/api.go
@@ -112,7 +112,7 @@ func (p *Plugin) setFilePermissions(w http.ResponseWriter, r *http.Request) {
 	fileInfo, fileInfoError := p.API.GetFileInfo(fileID)
 	if fileInfoError != nil {
 		p.API.LogError("Error when retrieving file info: ", fileInfoError.Error())
-		http.Error(w, "File not found. Invalid fileID: " + fileID, http.StatusBadRequest)
+		http.Error(w, "File not found. Invalid fileID: "+fileID, http.StatusBadRequest)
 		return
 	}
 
@@ -132,7 +132,7 @@ func (p *Plugin) setFilePermissions(w http.ResponseWriter, r *http.Request) {
 
 	permissionQuery := r.URL.Query().Get("permission")
 	var allowedPermissions = map[string]bool{
-		"owner": true, // permission owner allows only the owner to edit the file
+		"owner":   true, // permission owner allows only the owner to edit the file
 		"channel": true, // permission channel allows only all channel members to edit the file
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -10,6 +10,8 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/model"
 
@@ -30,9 +32,9 @@ func (p *Plugin) InitAPI() *mux.Router {
 
 	// Add the custom plugin routes here
 	s.HandleFunc("/config", p.getWebappConfig).Methods(http.MethodGet)
-	s.HandleFunc("/files/{fileID:[A-Za-z0-9_-]+}/access", handleAuthRequired(p.setFilePermissions)).Methods(http.MethodPost)
+	s.HandleFunc("/files/{fileID:[A-Za-z0-9_-]+}/access", handleAuthRequired(p.handleSaveFilePermissions)).Methods(http.MethodPost)
 	s.HandleFunc("/channels/{channelID:[A-Za-z0-9_-]+}/files/new", handleAuthRequired(p.createFileFromTemplate)).Methods(http.MethodPost).Queries("name", "{name}", "ext", "{ext}")
-	s.HandleFunc("/fileInfo", handleAuthRequired(p.parseFileIDs)).Methods(http.MethodGet)
+	s.HandleFunc("/fileInfo", handleAuthRequired(p.getClientFileInfos)).Methods(http.MethodGet)
 	s.HandleFunc("/wopiFileList", handleAuthRequired(p.returnWopiFileList)).Methods(http.MethodGet)
 	s.HandleFunc("/collaboraURL", handleAuthRequired(p.returnCollaboraOnlineFileURL)).Methods(http.MethodGet)
 	s.HandleFunc("/wopi/files/{fileID:[a-z0-9]+}", p.getWopiFileInfo).Methods(http.MethodGet)
@@ -106,51 +108,59 @@ func (p *Plugin) getWebappConfig(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(responseJSON)
 }
 
-func (p *Plugin) setFilePermissions(w http.ResponseWriter, r *http.Request) {
+// handleSaveFilePermissions allows setting file permissions when the edit permissions system console setting is enabled.
+func (p *Plugin) handleSaveFilePermissions(w http.ResponseWriter, r *http.Request) {
+	conf := p.getConfiguration()
+	if !conf.FileEditPermissions {
+		p.API.LogError("handleSaveFilePermissions: Edit permissions feature is disabled in system console.")
+		http.Error(w, "Edit permissions feature is disabled in system console.", http.StatusBadRequest)
+		return
+	}
+
 	params := mux.Vars(r)
 	fileID := params["fileID"]
-	fileInfo, fileInfoError := p.API.GetFileInfo(fileID)
-	if fileInfoError != nil {
-		p.API.LogError("Error when retrieving file info: ", fileInfoError.Error())
-		http.Error(w, "File not found. Invalid fileID: "+fileID, http.StatusBadRequest)
-		return
-	}
-
-	post, postError := p.API.GetPost(fileInfo.PostId)
-	if postError != nil {
-		p.API.LogError("Error occurred when retrieving post info for file: " + postError.Error())
-		http.Error(w, postError.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	userID := r.Header.Get(HeaderMattermostUserID)
-	if post.UserId != userID {
-		p.API.LogError("User does not have access to change file permissions.")
-		http.Error(w, "Only the owner can change file permissions.", http.StatusBadRequest)
-		return
-	}
-
 	permissionQuery := r.URL.Query().Get("permission")
-	var allowedPermissions = map[string]bool{
-		"owner":   true, // permission owner allows only the owner to edit the file
-		"channel": true, // permission channel allows only all channel members to edit the file
-	}
-
-	if _, ok := allowedPermissions[permissionQuery]; !ok {
+	if _, ok := AllowedFilePermissions[permissionQuery]; !ok {
 		p.API.LogError("Invalid permission query param.", "permissionQuery", permissionQuery)
 		http.Error(w, "Invalid permission query param.", http.StatusBadRequest)
 		return
 	}
 
-	filePermissionsKey := GetFilePermissionsKey(fileID)
-	post.AddProp(filePermissionsKey, permissionQuery)
-	if _, postErr := p.API.UpdatePost(post); postErr != nil {
-		p.API.LogError("Failed to update post", "Error", postErr.Error())
-		http.Error(w, postErr.Error(), http.StatusInternalServerError)
+	if err := p.setFilePermissions(fileID, userID, permissionQuery); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	returnStatusOK(w)
+}
+
+func (p *Plugin) setFilePermissions(fileID, userID, permission string) error {
+	fileInfo, fileInfoError := p.API.GetFileInfo(fileID)
+	if fileInfoError != nil {
+		p.API.LogError("Error when retrieving file info: ", fileInfoError.Error(), "fileID", fileID)
+		return errors.Wrap(fileInfoError, "error when retrieving file info, invalid fileID")
+	}
+
+	post, postError := p.API.GetPost(fileInfo.PostId)
+	if postError != nil {
+		p.API.LogError("Error occurred when retrieving post info for file: " + postError.Error())
+		return errors.Wrap(postError, "error when retrieving post for file")
+	}
+
+	if post.UserId != userID {
+		p.API.LogError("User does not have access to change file permissions.")
+		return errors.New("only the file owner can change file permissions")
+	}
+
+	filePermissionsKey := GetFilePermissionsKey(fileID)
+	post.AddProp(filePermissionsKey, permission)
+	if _, postErr := p.API.UpdatePost(post); postErr != nil {
+		p.API.LogError("Failed to update post", "Error", postErr.Error())
+		return errors.Wrap(postError, "error when saving post with updated permissions")
+	}
+
+	return nil
 }
 
 // createFileFromTemplate creates a new file from template in the given channel
@@ -222,9 +232,9 @@ func (p *Plugin) createFileFromTemplate(w http.ResponseWriter, r *http.Request) 
 	returnStatusOK(w)
 }
 
-// parseFileIDs sends the file info to the client (name, extension and id) for each file
-// body contains an array with file ids in JSON format
-func (p *Plugin) parseFileIDs(w http.ResponseWriter, r *http.Request) {
+// getClientFileInfos sends the ClientFileInfo (name, extension and id) for each file to the client.
+// The response body contains an array with file ids in JSON format.
+func (p *Plugin) getClientFileInfos(w http.ResponseWriter, r *http.Request) {
 	// extract fileIDs array from body
 	body, bodyReadError := ioutil.ReadAll(r.Body)
 	if bodyReadError != nil {
@@ -281,15 +291,36 @@ func (p *Plugin) returnCollaboraOnlineFileURL(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	file, fileError := p.API.GetFileInfo(fileID)
+	fileInfo, fileError := p.API.GetFileInfo(fileID)
 	if fileError != nil {
 		p.API.LogError("Failed to retrieve file. Error: ", fileError.Error())
 		http.Error(w, "Invalid fileID. Error: "+fileError.Error(), http.StatusBadRequest)
 		return
 	}
 
-	wopiURL := WopiFiles[strings.ToLower(file.Extension)].URL + "WOPISrc=" + (p.getBaseAPIURL() + "/wopi/files/" + fileID)
-	wopiToken := p.EncodeToken(r.Header.Get(HeaderMattermostUserID), fileID)
+	post, postError := p.API.GetPost(fileInfo.PostId)
+	if postError != nil {
+		p.API.LogError("Error occurred when retrieving post info for file: " + postError.Error())
+		http.Error(w, postError.Error(), http.StatusBadRequest)
+		return
+	}
+
+	userID := r.Header.Get(HeaderMattermostUserID)
+	conf := p.getConfiguration()
+	existingFilePermission := post.GetProp(GetFilePermissionsKey(fileID))
+
+	// initialize file permission if not already exists
+	if conf.FileEditPermissions && existingFilePermission == "" {
+		// If the edit permissions feature is enabled,
+		// set the default permission to allow only the owner to edit
+		if err := p.setFilePermissions(fileID, userID, PermissionOwner); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	wopiURL := WopiFiles[strings.ToLower(fileInfo.Extension)].URL + "WOPISrc=" + (p.getBaseAPIURL() + "/wopi/files/" + fileID)
+	wopiToken := p.EncodeToken(userID, fileID)
 
 	response := struct {
 		URL         string `json:"url"`
@@ -371,9 +402,14 @@ func (p *Plugin) saveWopiFileContents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check if user has access to the channel where the file was sent
-	if !p.API.HasPermissionToChannel(wopiToken.UserID, post.ChannelId, model.PERMISSION_READ_CHANNEL) {
-		p.API.LogError("User: " + wopiToken.UserID + " does not have the appropriate permissions: PERMISSION_READ_CHANNEL. Channel: " + post.ChannelId)
+	conf := p.getConfiguration()
+	filePermission := post.GetProp(GetFilePermissionsKey(fileID))
+	canChannelEdit := !conf.FileEditPermissions || filePermission == PermissionChannel
+	canOwnerOnlyEdit := conf.FileEditPermissions && filePermission == PermissionOwner
+	canCurrentUserEdit := (canChannelEdit && p.API.HasPermissionToChannel(wopiToken.UserID, post.ChannelId, model.PERMISSION_READ_CHANNEL)) || (canOwnerOnlyEdit && post.UserId == wopiToken.UserID)
+
+	if !canCurrentUserEdit {
+		p.API.LogError("User does not have the appropriate permissions to edit the file.", "channelID", post.ChannelId, "userID", wopiToken.UserID)
 		http.Error(w, "You do not have the appropriate permissions.", http.StatusForbidden)
 		return
 	}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -27,7 +27,20 @@ var (
 		"ods":  "template.ods",
 	}
 
+	// WebsocketEventConfigUpdated is the websocket event called to update plugin config on clients' webapp
 	WebsocketEventConfigUpdated = "config_updated"
+
+	// PermissionOwner allows only the owner to edit the file
+	PermissionOwner = "owner"
+
+	// PermissionChannel allows only all channel members to edit the file
+	PermissionChannel = "channel"
+
+	// AllowedFilePermissions is the list of file permissions
+	AllowedFilePermissions = map[string]bool{
+		PermissionOwner:   true,
+		PermissionChannel: true,
+	}
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -26,6 +26,8 @@ var (
 		"xlsx": "xlsxtemplate.xlsx",
 		"ods":  "template.ods",
 	}
+
+	WebsocketEventConfigUpdated = "config_updated"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server
@@ -40,9 +42,17 @@ var (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	WOPIAddress   string
-	SkipSSLVerify bool
-	EncryptionKey string
+	WOPIAddress         string
+	SkipSSLVerify       bool
+	EncryptionKey       string
+	FileEditPermissions bool
+}
+
+// ToWebappConfig initializes the webapp config from configuration
+func (c *configuration) ToWebappConfig() *WebappConfig {
+	return &WebappConfig{
+		c.FileEditPermissions,
+	}
 }
 
 // Clone deep copies the configuration

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -55,7 +55,7 @@ func (p *Plugin) OnConfigurationChange() error {
 }
 
 // UserHasLoggedIn is invoked after a user has logged in.
-func  (p *Plugin) UserHasLoggedIn(c *plugin.Context, user *model.User) {
+func (p *Plugin) UserHasLoggedIn(c *plugin.Context, user *model.User) {
 	// send the config to the webapp
 	config := p.getConfiguration().ToWebappConfig()
 	p.API.PublishWebSocketEvent(WebsocketEventConfigUpdated, config.ToMap(), &model.WebsocketBroadcast{})

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 	"github.com/pkg/errors"
 )
@@ -46,7 +47,18 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	p.setConfiguration(configuration)
+
+	// send the updated config to the webapp
+	p.API.PublishWebSocketEvent(WebsocketEventConfigUpdated, configuration.ToWebappConfig().ToMap(), &model.WebsocketBroadcast{})
+
 	return nil
+}
+
+// UserHasLoggedIn is invoked after a user has logged in.
+func  (p *Plugin) UserHasLoggedIn(c *plugin.Context, user *model.User) {
+	// send the config to the webapp
+	config := p.getConfiguration().ToWebappConfig()
+	p.API.PublishWebSocketEvent(WebsocketEventConfigUpdated, config.ToMap(), &model.WebsocketBroadcast{})
 }
 
 // ServeHTTP handles HTTP requests for the plugin.

--- a/server/serializers.go
+++ b/server/serializers.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"encoding/json"
 	"encoding/xml"
 
 	"github.com/dgrijalva/jwt-go"
 )
+
+type WebappConfig struct {
+	FileEditPermissions bool `json:"file_edit_permissions"`
+}
+
+func (c *WebappConfig) ToMap() map[string]interface{} {
+	out := make(map[string]interface{})
+	b, _ := json.Marshal(c)
+	_ = json.Unmarshal(b, &out)
+	return out
+}
 
 // WopiToken is the token used for WOPI authentication.
 // When a user wants to open a file with Collabora Online this token is passed to Collabora Online

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"crypto/tls"
-	root "github.com/CollaboraOnline/collabora-mattermost"
 	"io"
 	"net/http"
+
+	root "github.com/CollaboraOnline/collabora-mattermost"
 
 	"github.com/mattermost/mattermost-server/v5/shared/filestore"
 )

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	root "github.com/CollaboraOnline/collabora-mattermost"
 	"io"
 	"net/http"
 
@@ -41,4 +42,8 @@ func (p *Plugin) GetHTTPClient() *http.Client {
 
 	client := &http.Client{Transport: customTransport}
 	return client
+}
+
+func GetFilePermissionsKey(fileID string) string {
+	return root.Manifest.Id + "_file_permissions_" + fileID
 }

--- a/webapp/src/actions/config.ts
+++ b/webapp/src/actions/config.ts
@@ -1,0 +1,41 @@
+import {AnyAction, Dispatch} from 'redux';
+import {ThunkAction, ThunkDispatch} from 'redux-thunk';
+import {ActionResult} from 'mattermost-redux/types/actions';
+import {GlobalState} from 'mattermost-webapp/types/store/index';
+
+import Constants from '../constants';
+import Client from 'client';
+
+export const setConfig = (data: unknown) => {
+    return async (dispatch: Dispatch) => {
+        dispatch({
+            type: Constants.ACTION_TYPES.RECEIVED_CLIENT_CONFIG,
+            data,
+        });
+    };
+};
+
+export const getConfig = (): ThunkAction<Promise<ActionResult>, any, undefined, AnyAction> => {
+    return async (dispatch: ThunkDispatch<GlobalState, undefined, AnyAction>) => {
+        let data = null;
+        try {
+            data = await Client.getConfig();
+            dispatch(setConfig(data));
+        } catch (error) {
+            dispatch({
+                type: Constants.ACTION_TYPES.CLIENT_CONFIG_ERROR,
+                error,
+            });
+
+            return {
+                data,
+                error,
+            };
+        }
+
+        return {
+            data,
+            error: null,
+        };
+    };
+};

--- a/webapp/src/actions/file.ts
+++ b/webapp/src/actions/file.ts
@@ -1,8 +1,8 @@
 import {Dispatch} from 'redux';
 
-import {DispatchFunc} from 'mattermost-redux/types/actions';
+import {ActionResult, DispatchFunc} from 'mattermost-redux/types/actions';
 
-import Constants, {TEMPLATE_TYPES} from '../constants';
+import Constants, {FILE_EDIT_PERMISSIONS, TEMPLATE_TYPES} from '../constants';
 import Client from '../client';
 
 export const showFileCreateModal = (templateType: TEMPLATE_TYPES) => (dispatch: Dispatch) => {
@@ -23,6 +23,18 @@ export function createFileFromTemplate(channelID: string, name: string, ext: str
         let data = null;
         try {
             data = await Client.createFileFromTemplate(channelID, name, ext);
+        } catch (error) {
+            return {data, error};
+        }
+        return {data, error: null};
+    };
+}
+
+export function updateFileEditPermission(fileID: string, permission: FILE_EDIT_PERMISSIONS) {
+    return async (): Promise<ActionResult> => {
+        let data = null;
+        try {
+            data = await Client.updateFileEditPermission(fileID, permission);
         } catch (error) {
             return {data, error};
         }

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -1,8 +1,11 @@
+import {getConfig, setConfig} from './config';
 import {getWopiFilesList, getCollaboraFileURL} from './wopi';
 import {showFilePreview, closeFilePreview} from './preview';
 import {createFileFromTemplate, closeFileCreateModal, showFileCreateModal} from './file';
 
 export default {
+    getConfig,
+    setConfig,
     showFilePreview,
     closeFilePreview,
     getCollaboraFileURL,

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -15,6 +15,10 @@ export default class Client {
         this.baseURL = `/plugins/${pluginId}/api/v1`;
     }
 
+    getConfig = () => {
+        return this.doGet(`${this.baseURL}/config`);
+    }
+
     createFileFromTemplate = (channelID: string, name: string, ext: string) => {
         const params = {name, ext};
         return this.doPost(`${this.baseURL}/channels/${channelID}/files/new${this.buildQueryString(params)}`);

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -5,6 +5,7 @@ import {ClientError} from 'mattermost-redux/client/client4';
 import {Options} from 'mattermost-redux/types/client4';
 
 import {id as pluginId} from '../manifest';
+import {FILE_EDIT_PERMISSIONS} from '../constants';
 
 export default class Client {
     apiURL: string;
@@ -17,6 +18,12 @@ export default class Client {
 
     getConfig = () => {
         return this.doGet(`${this.baseURL}/config`);
+    }
+
+    updateFileEditPermission = (fileID: string, permission: FILE_EDIT_PERMISSIONS) => {
+        const params = {permission};
+        const url = `${this.baseURL}/files/${fileID}/access${this.buildQueryString(params)}`;
+        return this.doPost(url);
     }
 
     createFileFromTemplate = (channelID: string, name: string, ext: string) => {

--- a/webapp/src/components/file_preview_component.tsx
+++ b/webapp/src/components/file_preview_component.tsx
@@ -4,7 +4,15 @@ import {Button} from 'react-bootstrap';
 
 import {FileInfo} from 'mattermost-redux/types/files';
 
+import {useSelector} from 'react-redux';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
 import WopiFilePreview from 'components/wopi_file_preview';
+import {collaboraConfig} from '../selectors';
+import {id as pluginId} from '../manifest';
+import {FILE_EDIT_PERMISSIONS} from "../constants";
 
 type Props = {
     fileInfo: FileInfo;
@@ -13,7 +21,19 @@ type Props = {
 const FilePreviewComponent: FC<Props> = ({fileInfo}: Props) => {
     const [loading, setLoading] = useState(true);
     const [editable, setEditable] = useState(false);
-    const enableEditing = useCallback(() => setEditable(true), []);
+    const enableEditing = useCallback(() => {
+        setEditable(true);
+    }, []);
+
+    const post = useSelector((state: GlobalState) => getPost(state, fileInfo.post_id || ''));
+    const currentUser = useSelector(getCurrentUser);
+    const collaboraConf = useSelector(collaboraConfig);
+
+    const editPermissionsFeatureEnabled = collaboraConf.file_edit_permissions;
+    const showEditPermissionChangeOption = editPermissionsFeatureEnabled && post?.user_id === currentUser.id;
+    const canChannelEdit = post?.props?.[pluginId + '_file_permissions_' + fileInfo.id] === FILE_EDIT_PERMISSIONS.PERMISSION_CHANNEL;
+    const canCurrentUserEdit = showEditPermissionChangeOption || canChannelEdit;
+
     return (
         <>
             <WopiFilePreview
@@ -21,7 +41,7 @@ const FilePreviewComponent: FC<Props> = ({fileInfo}: Props) => {
                 editable={editable}
                 setLoading={setLoading}
             />
-            {!loading && !editable && (
+            {canCurrentUserEdit && !loading && !editable && (
                 <Button onClick={enableEditing}>
                     <span className='wopi-switch-to-edit-mode'>
                         <i className='fa fa-pencil-square-o'/>

--- a/webapp/src/components/file_preview_component.tsx
+++ b/webapp/src/components/file_preview_component.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useCallback, useState} from 'react';
+import React, {FC, useCallback, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {Button} from 'react-bootstrap';
 
@@ -6,7 +6,7 @@ import {FileInfo} from 'mattermost-redux/types/files';
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import WopiFilePreview from 'components/wopi_file_preview';
-import {collaboraFileEditPermissionsEnabled, makeGetCollaboraFilePermissions, makeGetIsCurrentUserFileOwner} from 'selectors';
+import {enableEditPermissions, makeGetCollaboraFilePermissions, makeGetIsCurrentUserFileOwner} from 'selectors';
 
 import {FILE_EDIT_PERMISSIONS} from '../constants';
 
@@ -25,7 +25,7 @@ const FilePreviewComponent: FC<Props> = ({fileInfo}: Props) => {
     const getCollaboraFilePermissions = useMemo(makeGetCollaboraFilePermissions, []);
     const isCurrentUserOwner = useSelector((state: GlobalState) => getIsCurrentUserFileOwner(state, fileInfo));
     const filePermission = useSelector((state: GlobalState) => getCollaboraFilePermissions(state, fileInfo));
-    const editPermissionsFeatureEnabled = useSelector(collaboraFileEditPermissionsEnabled);
+    const editPermissionsFeatureEnabled = useSelector(enableEditPermissions);
 
     const showEditPermissionChangeOption = editPermissionsFeatureEnabled && isCurrentUserOwner;
     const canChannelEdit = filePermission === FILE_EDIT_PERMISSIONS.PERMISSION_CHANNEL;

--- a/webapp/src/components/file_preview_component.tsx
+++ b/webapp/src/components/file_preview_component.tsx
@@ -21,8 +21,8 @@ const FilePreviewComponent: FC<Props> = ({fileInfo}: Props) => {
         setEditable(true);
     }, []);
 
-    const getIsCurrentUserFileOwner = makeGetIsCurrentUserFileOwner();
-    const getCollaboraFilePermissions = makeGetCollaboraFilePermissions();
+    const getIsCurrentUserFileOwner = useMemo(makeGetIsCurrentUserFileOwner, []);
+    const getCollaboraFilePermissions = useMemo(makeGetCollaboraFilePermissions, []);
     const isCurrentUserOwner = useSelector((state: GlobalState) => getIsCurrentUserFileOwner(state, fileInfo));
     const filePermission = useSelector((state: GlobalState) => getCollaboraFilePermissions(state, fileInfo));
     const editPermissionsFeatureEnabled = useSelector(collaboraFileEditPermissionsEnabled);

--- a/webapp/src/components/file_preview_header.tsx
+++ b/webapp/src/components/file_preview_header.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useMemo, useState} from 'react';
+import React, {FC, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 import clsx from 'clsx';
 import {Button} from 'react-bootstrap';
@@ -7,10 +7,8 @@ import {FileInfo} from 'mattermost-redux/types/files';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import Client from 'client';
-import {collaboraConfig} from 'selectors';
 
 import {CHANNEL_TYPES} from '../constants';
 
@@ -21,9 +19,13 @@ type Props = {
     onClose: () => void;
     editable: boolean;
     toggleEditing: () => void;
+    canChannelEdit: boolean;
+    toggleCanChannelEdit: () => void;
+    showEditPermissionChangeOption: boolean;
 }
 
-export const FilePreviewHeader: FC<Props> = ({fileInfo, onClose, editable, toggleEditing}: Props) => {
+export const FilePreviewHeader: FC<Props> = (props: Props) => {
+    const {fileInfo, onClose, editable, toggleEditing, canChannelEdit, toggleCanChannelEdit, showEditPermissionChangeOption} = props;
     const post = useSelector((state: GlobalState) => getPost(state, fileInfo.post_id || ''));
     const channel = useSelector((state: GlobalState) => getChannel(state, post?.channel_id));
     const channelName: React.ReactNode = useMemo(() => {
@@ -43,15 +45,7 @@ export const FilePreviewHeader: FC<Props> = ({fileInfo, onClose, editable, toggl
         }
     }, [channel]);
 
-    const currentUser = useSelector(getCurrentUser);
-    const collaboraConf = useSelector(collaboraConfig);
-
-    const editPermissionsFeatureEnabled = collaboraConf.file_edit_permissions;
-    const showEditPermissionChangeOption = editPermissionsFeatureEnabled && post.user_id === currentUser.id;
-    const [canChannelEdit, setCanChannelEdit] = useState(true);
-    const toggleCanChannelEdit = () => {
-        setCanChannelEdit((prevState) => !prevState);
-    };
+    const canCurrentUserEdit = showEditPermissionChangeOption || canChannelEdit;
 
     return (
         <>
@@ -136,10 +130,11 @@ export const FilePreviewHeader: FC<Props> = ({fileInfo, onClose, editable, toggl
                     <Button
                         bsSize='large'
                         bsStyle='large'
+                        disabled={!canCurrentUserEdit}
                         onClick={toggleEditing}
                         className='collabora-header-action-button'
-                        title={`${editable ? 'Lock' : 'Unlock'} Editing`}
-                        aria-label={`${editable ? 'Lock' : 'Unlock'} Editing`}
+                        title={`${editable ? 'Lock' : 'Unlock'} Editing${!canCurrentUserEdit ? ' (disabled as only the owner can edit)' : ''}`}
+                        aria-label={`${editable ? 'Lock' : 'Unlock'} Editing${!canCurrentUserEdit ? ' (disabled as only the owner can edit)' : ''}`}
                     >
                         <i
                             className={clsx(

--- a/webapp/src/components/file_preview_header.tsx
+++ b/webapp/src/components/file_preview_header.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useMemo} from 'react';
+import React, {FC, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 import clsx from 'clsx';
 import {Button} from 'react-bootstrap';
@@ -7,8 +7,10 @@ import {FileInfo} from 'mattermost-redux/types/files';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import Client from 'client';
+import {collaboraConfig} from 'selectors';
 
 import {CHANNEL_TYPES} from '../constants';
 
@@ -40,6 +42,16 @@ export const FilePreviewHeader: FC<Props> = ({fileInfo, onClose, editable, toggl
             return channel.display_name;
         }
     }, [channel]);
+
+    const currentUser = useSelector(getCurrentUser);
+    const collaboraConf = useSelector(collaboraConfig);
+
+    const editPermissionsFeatureEnabled = collaboraConf.file_edit_permissions;
+    const showEditPermissionChangeOption = editPermissionsFeatureEnabled && post.user_id === currentUser.id;
+    const [canChannelEdit, setCanChannelEdit] = useState(true);
+    const toggleCanChannelEdit = () => {
+        setCanChannelEdit((prevState) => !prevState);
+    };
 
     return (
         <>
@@ -139,7 +151,27 @@ export const FilePreviewHeader: FC<Props> = ({fileInfo, onClose, editable, toggl
                             )}
                         />
                     </Button>
-
+                    {
+                        showEditPermissionChangeOption && (
+                            <Button
+                                bsStyle='large'
+                                onClick={toggleCanChannelEdit}
+                                className='collabora-header-action-button'
+                                title={canChannelEdit ? 'Everyone in the channel can edit.' : 'Only you can edit.'}
+                                aria-label={canChannelEdit ? 'Everyone in the channel can edit.' : 'Only you can edit.'}
+                            >
+                                <i
+                                    className={clsx(
+                                        'fa',
+                                        {
+                                            'fa-users': canChannelEdit,
+                                            'fa-user': !canChannelEdit,
+                                        },
+                                    )}
+                                />
+                            </Button>
+                        )
+                    }
                     <div className='collabora-header-actions-separator'/>
                     <CloseIcon
                         id='closeIcon'

--- a/webapp/src/components/file_preview_header.tsx
+++ b/webapp/src/components/file_preview_header.tsx
@@ -1,16 +1,11 @@
-import React, {FC, useMemo} from 'react';
-import {useSelector} from 'react-redux';
+import React, {FC} from 'react';
 import clsx from 'clsx';
 import {Button} from 'react-bootstrap';
 
 import {FileInfo} from 'mattermost-redux/types/files';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import Client from 'client';
-
-import {CHANNEL_TYPES} from '../constants';
+import {useChannelName} from 'hooks/useChannelName';
 
 import CloseIcon from './close_icon';
 
@@ -26,25 +21,7 @@ type Props = {
 
 export const FilePreviewHeader: FC<Props> = (props: Props) => {
     const {fileInfo, onClose, editable, toggleEditing, canChannelEdit, toggleCanChannelEdit, showEditPermissionChangeOption} = props;
-    const post = useSelector((state: GlobalState) => getPost(state, fileInfo.post_id || ''));
-    const channel = useSelector((state: GlobalState) => getChannel(state, post?.channel_id));
-    const channelName: React.ReactNode = useMemo(() => {
-        if (!channel) {
-            return '';
-        }
-
-        switch (channel.type) {
-        case CHANNEL_TYPES.CHANNEL_DIRECT:
-            return 'Direct Message';
-
-        case CHANNEL_TYPES.CHANNEL_GROUP:
-            return 'Group Message';
-
-        default:
-            return channel.display_name;
-        }
-    }, [channel]);
-
+    const channelName: React.ReactNode = useChannelName(fileInfo);
     const canCurrentUserEdit = showEditPermissionChangeOption || canChannelEdit;
 
     return (

--- a/webapp/src/components/file_preview_header.tsx
+++ b/webapp/src/components/file_preview_header.tsx
@@ -23,6 +23,7 @@ export const FilePreviewHeader: FC<Props> = (props: Props) => {
     const {fileInfo, onClose, editable, toggleEditing, canChannelEdit, toggleCanChannelEdit, showEditPermissionChangeOption} = props;
     const channelName: React.ReactNode = useChannelName(fileInfo);
     const canCurrentUserEdit = showEditPermissionChangeOption || canChannelEdit;
+    const editModeTitle = `${editable ? 'Lock' : 'Unlock'} Editing${canCurrentUserEdit ? '' : ' (disabled as only the owner can edit)'}`;
 
     return (
         <>
@@ -110,8 +111,8 @@ export const FilePreviewHeader: FC<Props> = (props: Props) => {
                         disabled={!canCurrentUserEdit}
                         onClick={toggleEditing}
                         className='collabora-header-action-button'
-                        title={`${editable ? 'Lock' : 'Unlock'} Editing${!canCurrentUserEdit ? ' (disabled as only the owner can edit)' : ''}`}
-                        aria-label={`${editable ? 'Lock' : 'Unlock'} Editing${!canCurrentUserEdit ? ' (disabled as only the owner can edit)' : ''}`}
+                        title={editModeTitle}
+                        aria-label={editModeTitle}
                     >
                         <i
                             className={clsx(

--- a/webapp/src/components/file_preview_modal.tsx
+++ b/webapp/src/components/file_preview_modal.tsx
@@ -4,16 +4,15 @@ import {ThunkDispatch} from 'redux-thunk';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {FileInfo} from 'mattermost-redux/types/files';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {GlobalState} from 'mattermost-redux/types/store';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
+import {updateFileEditPermission} from 'actions/file';
 import {closeFilePreview} from 'actions/preview';
 import {
-    collaboraConfig, collaboraFileEditPermissionsEnabled,
+    collaboraFileEditPermissionsEnabled,
     filePreviewModal,
     makeGetCollaboraFilePermissions,
-    makeGetIsCurrentUserFileOwner
+    makeGetIsCurrentUserFileOwner,
 } from 'selectors';
 
 import FullScreenModal from 'components/full_screen_modal';
@@ -21,8 +20,6 @@ import WopiFilePreview from 'components/wopi_file_preview';
 import FilePreviewHeader from 'components/file_preview_header';
 
 import {FILE_EDIT_PERMISSIONS} from '../constants';
-import {updateFileEditPermission} from '../actions/file';
-import {id as pluginId} from '../manifest';
 
 type FilePreviewModalSelector = {
     visible: boolean;

--- a/webapp/src/components/file_preview_modal.tsx
+++ b/webapp/src/components/file_preview_modal.tsx
@@ -34,8 +34,8 @@ const FilePreviewModal: FC = () => {
         setEditable((prevState) => !prevState);
     }, [setEditable]);
 
-    const getIsCurrentUserFileOwner = makeGetIsCurrentUserFileOwner();
-    const getCollaboraFilePermissions = makeGetCollaboraFilePermissions();
+    const getIsCurrentUserFileOwner = useMemo(makeGetIsCurrentUserFileOwner, []);
+    const getCollaboraFilePermissions = useMemo(makeGetCollaboraFilePermissions, []);
     const isCurrentUserOwner = useSelector((state: GlobalState) => getIsCurrentUserFileOwner(state, fileInfo));
     const filePermission = useSelector((state: GlobalState) => getCollaboraFilePermissions(state, fileInfo));
     const editPermissionsFeatureEnabled = useSelector(collaboraFileEditPermissionsEnabled);

--- a/webapp/src/components/file_preview_modal.tsx
+++ b/webapp/src/components/file_preview_modal.tsx
@@ -30,6 +30,7 @@ const FilePreviewModal: FC = () => {
         }
 
         dispatch(closeFilePreview());
+        setEditable(false);
     }, [dispatch]);
 
     return (

--- a/webapp/src/components/file_preview_modal.tsx
+++ b/webapp/src/components/file_preview_modal.tsx
@@ -1,15 +1,23 @@
-import React, {FC, useCallback, useState} from 'react';
-
-import {FileInfo} from 'mattermost-redux/types/files';
-
+import React, {FC, useCallback, useEffect, useState} from 'react';
+import {AnyAction} from 'redux';
+import {ThunkDispatch} from 'redux-thunk';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {FileInfo} from 'mattermost-redux/types/files';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+
 import {closeFilePreview} from 'actions/preview';
-import {filePreviewModal} from 'selectors';
+import {collaboraConfig, filePreviewModal} from 'selectors';
 
 import FullScreenModal from 'components/full_screen_modal';
 import WopiFilePreview from 'components/wopi_file_preview';
 import FilePreviewHeader from 'components/file_preview_header';
+
+import {FILE_EDIT_PERMISSIONS} from '../constants';
+import {updateFileEditPermission} from '../actions/file';
+import {id as pluginId} from '../manifest';
 
 type FilePreviewModalSelector = {
     visible: boolean;
@@ -17,12 +25,46 @@ type FilePreviewModalSelector = {
 }
 
 const FilePreviewModal: FC = () => {
-    const dispatch = useDispatch();
+    const dispatch: ThunkDispatch<GlobalState, undefined, AnyAction> = useDispatch();
     const {visible, fileInfo}: FilePreviewModalSelector = useSelector(filePreviewModal);
     const [editable, setEditable] = useState(false);
     const toggleEditing = useCallback(() => {
         setEditable((prevState) => !prevState);
     }, [setEditable]);
+
+    const post = useSelector((state: GlobalState) => getPost(state, fileInfo?.post_id || ''));
+    const currentUser = useSelector(getCurrentUser);
+    const collaboraConf = useSelector(collaboraConfig);
+
+    const editPermissionsFeatureEnabled = collaboraConf.file_edit_permissions;
+    const showEditPermissionChangeOption = editPermissionsFeatureEnabled && post?.user_id === currentUser.id;
+
+    const [canChannelEdit, setCanChannelEdit] = useState(false);
+    const toggleCanChannelEdit = async () => {
+        await setCanChannelEdit((prevState: boolean) => !prevState);
+        const updatedPermission = canChannelEdit ? FILE_EDIT_PERMISSIONS.PERMISSION_OWNER : FILE_EDIT_PERMISSIONS.PERMISSION_CHANNEL;
+        const response = await dispatch(updateFileEditPermission(fileInfo.id, updatedPermission));
+        if ((response as {error: unknown}).error) {
+            // TODO handle error
+            setCanChannelEdit((prevState: boolean) => !prevState);
+        } else if (!canChannelEdit) {
+            setEditable(false);
+        }
+    };
+
+    useEffect(() => {
+        let defaultCanChannelEdit = true;
+        if (editPermissionsFeatureEnabled) {
+            defaultCanChannelEdit = post?.props?.[pluginId + '_file_permissions_' + fileInfo.id] === FILE_EDIT_PERMISSIONS.PERMISSION_CHANNEL;
+        }
+
+        setCanChannelEdit(defaultCanChannelEdit);
+
+        const userHasEditPermission = showEditPermissionChangeOption || canChannelEdit;
+        if (!userHasEditPermission) {
+            setEditable(false);
+        }
+    }, [canChannelEdit, editPermissionsFeatureEnabled, fileInfo.id, post, showEditPermissionChangeOption]);
 
     const handleClose = useCallback((e?: Event): void => {
         if (e && e.preventDefault) {
@@ -43,6 +85,9 @@ const FilePreviewModal: FC = () => {
                 onClose={handleClose}
                 editable={editable}
                 toggleEditing={toggleEditing}
+                canChannelEdit={canChannelEdit}
+                toggleCanChannelEdit={toggleCanChannelEdit}
+                showEditPermissionChangeOption={showEditPermissionChangeOption}
             />
             <WopiFilePreview
                 fileInfo={fileInfo}

--- a/webapp/src/constants/action_types.ts
+++ b/webapp/src/constants/action_types.ts
@@ -2,6 +2,9 @@ import {id as pluginID} from '../manifest';
 
 export const RECEIVED_WOPI_FILES_LIST = pluginID + '_received_wopi_files_list';
 
+export const RECEIVED_CLIENT_CONFIG = pluginID + '_received_client_config';
+export const CLIENT_CONFIG_ERROR = pluginID + '_client_config_error';
+
 export const SHOW_FILE_PREVIEW = pluginID + '_show_file_preview';
 export const CLOSE_FILE_PREVIEW = pluginID + '_close_file_preview';
 

--- a/webapp/src/constants/index.ts
+++ b/webapp/src/constants/index.ts
@@ -21,10 +21,16 @@ export const CHANNEL_TYPES = {
     CHANNEL_GROUP: 'G',
 };
 
+export enum FILE_EDIT_PERMISSIONS {
+    PERMISSION_OWNER = 'owner',
+    PERMISSION_CHANNEL = 'channel',
+}
+
 export default Object.freeze({
     ACTION_TYPES,
     CHANNEL_TYPES,
     TEMPLATE_TYPES,
+    FILE_EDIT_PERMISSIONS,
     FILE_TEMPLATES,
     WEBSOCKET_EVENT_CONFIG_UPDATED: 'config_updated',
 });

--- a/webapp/src/constants/index.ts
+++ b/webapp/src/constants/index.ts
@@ -26,4 +26,5 @@ export default Object.freeze({
     CHANNEL_TYPES,
     TEMPLATE_TYPES,
     FILE_TEMPLATES,
+    WEBSOCKET_EVENT_CONFIG_UPDATED: 'config_updated',
 });

--- a/webapp/src/hooks/useChannelName.ts
+++ b/webapp/src/hooks/useChannelName.ts
@@ -1,0 +1,33 @@
+import {useMemo} from 'react';
+import {useSelector} from 'react-redux';
+
+import {FileInfo} from 'mattermost-redux/types/files';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+
+import {CHANNEL_TYPES} from '../constants';
+
+// Hook
+// Returns channelName for file
+// Parameter used is the fileInfo
+export const useChannelName = (fileInfo: FileInfo) => {
+    const post = useSelector((state: GlobalState) => getPost(state, fileInfo.post_id || ''));
+    const channel = useSelector((state: GlobalState) => getChannel(state, post?.channel_id));
+    return useMemo(() => {
+        if (!channel) {
+            return '';
+        }
+
+        switch (channel.type) {
+        case CHANNEL_TYPES.CHANNEL_DIRECT:
+            return 'Direct Message';
+
+        case CHANNEL_TYPES.CHANNEL_GROUP:
+            return 'Group Message';
+
+        default:
+            return channel.display_name;
+        }
+    }, [channel]);
+};

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -5,7 +5,7 @@ import {ThunkDispatch} from 'redux-thunk';
 //@ts-ignore PluginRegistry doesn't have types yet
 import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
 
-import {GlobalState} from 'mattermost-webapp/types/store';
+import {GlobalState} from 'mattermost-redux/types/store';
 import {FileInfo} from 'mattermost-redux/types/files';
 import {WebSocketMessage} from 'mattermost-redux/types/websocket';
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -7,6 +7,7 @@ import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
 
 import {GlobalState} from 'mattermost-webapp/types/store';
 import {FileInfo} from 'mattermost-redux/types/files';
+import {WebSocketMessage} from 'mattermost-redux/types/websocket';
 
 import Actions from 'actions';
 import {wopiFilesList} from 'selectors';
@@ -21,7 +22,6 @@ import Constants, {TEMPLATE_TYPES} from './constants';
 import {id as pluginId} from './manifest';
 
 import './components/styles.css';
-import {WebSocketMessage} from "mattermost-redux/types/websocket";
 
 export default class Plugin {
     shouldShowPreview = (store: Store<GlobalState>, fileInfo: FileInfo) => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -8,9 +8,7 @@ import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
 import {GlobalState} from 'mattermost-webapp/types/store';
 import {FileInfo} from 'mattermost-redux/types/files';
 
-import {showFileCreateModal} from 'actions/file';
-import {showFilePreview} from 'actions/preview';
-import {getWopiFilesList} from 'actions/wopi';
+import Actions from 'actions';
 import {wopiFilesList} from 'selectors';
 import Reducer from 'reducers';
 
@@ -18,11 +16,12 @@ import FilePreviewModal from 'components/file_preview_modal';
 import FilePreviewComponent from 'components/file_preview_component';
 import FileCreateModal from 'components/file_create_modal';
 
-import {TEMPLATE_TYPES} from './constants';
+import Constants, {TEMPLATE_TYPES} from './constants';
 
 import {id as pluginId} from './manifest';
 
 import './components/styles.css';
+import {WebSocketMessage} from "mattermost-redux/types/websocket";
 
 export default class Plugin {
     shouldShowPreview = (store: Store<GlobalState>, fileInfo: FileInfo) => {
@@ -36,7 +35,12 @@ export default class Plugin {
         registry.registerRootComponent(FilePreviewModal);
         registry.registerRootComponent(FileCreateModal);
         const dispatch: ThunkDispatch<GlobalState, undefined, AnyAction> = store.dispatch;
-        dispatch(getWopiFilesList());
+        dispatch(Actions.getConfig());
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_${Constants.WEBSOCKET_EVENT_CONFIG_UPDATED}`, (event: WebSocketMessage<unknown>) => {
+            dispatch(Actions.setConfig(event.data));
+        });
+
+        dispatch(Actions.getWopiFilesList());
         registry.registerFilePreviewComponent(
             this.shouldShowPreview.bind(null, store),
             (props: {fileInfo: FileInfo}) => <FilePreviewComponent fileInfo={props.fileInfo}/>,
@@ -46,22 +50,22 @@ export default class Plugin {
         registry.registerFileDropdownMenuAction?.(
             this.shouldShowPreview.bind(null, store),
             'Open with Collabora',
-            (fileInfo: FileInfo) => dispatch(showFilePreview(fileInfo)),
+            (fileInfo: FileInfo) => dispatch(Actions.showFilePreview(fileInfo)),
         );
 
         registry.registerFileUploadMethod(
             <span className='fa wopi-file-upload-icon icon-filetype-document'/>,
-            () => dispatch(showFileCreateModal(TEMPLATE_TYPES.DOCUMENT)),
+            () => dispatch(Actions.showFileCreateModal(TEMPLATE_TYPES.DOCUMENT)),
             'New document',
         );
         registry.registerFileUploadMethod(
             <span className='fa wopi-file-upload-icon icon-filetype-spreadsheet'/>,
-            () => dispatch(showFileCreateModal(TEMPLATE_TYPES.SPREADSHEET)),
+            () => dispatch(Actions.showFileCreateModal(TEMPLATE_TYPES.SPREADSHEET)),
             'New spreadsheet',
         );
         registry.registerFileUploadMethod(
             <span className='fa wopi-file-upload-icon icon-filetype-presentation'/>,
-            () => dispatch(showFileCreateModal(TEMPLATE_TYPES.PRESENTATION)),
+            () => dispatch(Actions.showFileCreateModal(TEMPLATE_TYPES.PRESENTATION)),
             'New presentation',
         );
     }

--- a/webapp/src/reducers/config.ts
+++ b/webapp/src/reducers/config.ts
@@ -1,0 +1,14 @@
+import {AnyAction} from 'redux';
+
+import Constants from '../constants';
+
+export const config = (state = {}, action: AnyAction) => {
+    switch (action.type) {
+    case Constants.ACTION_TYPES.RECEIVED_CLIENT_CONFIG:
+        return action.data;
+    case Constants.ACTION_TYPES.CLIENT_CONFIG_ERROR:
+        return {};
+    default:
+        return state;
+    }
+};

--- a/webapp/src/reducers/index.ts
+++ b/webapp/src/reducers/index.ts
@@ -1,10 +1,12 @@
 import {combineReducers} from 'redux';
 
+import {config} from './config';
 import {wopiFilesList} from './wopi';
 import {filePreviewModal} from './file_preview_modal';
 import {createFileModal} from './create_file_modal';
 
 export default combineReducers({
+    config,
     wopiFilesList,
     filePreviewModal,
     createFileModal,

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -5,6 +5,8 @@ import {id as pluginId} from '../manifest';
 //@ts-ignore GlobalState is not complete
 const getPluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
 
+export const collaboraConfig = (state: GlobalState) => getPluginState(state).config;
+
 export const wopiFilesList = (state: GlobalState) => getPluginState(state).wopiFilesList;
 
 export const filePreviewModal = (state: GlobalState) => getPluginState(state).filePreviewModal;

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -19,7 +19,7 @@ export const createFileModal = (state: GlobalState) => getPluginState(state).cre
 
 export const collaboraConfig = (state: GlobalState) => getPluginState(state).config;
 
-export const collaboraFileEditPermissionsEnabled = (state: GlobalState) => Boolean(collaboraConfig(state)?.file_edit_permissions);
+export const enableEditPermissions = (state: GlobalState) => Boolean(collaboraConfig(state)?.file_edit_permissions);
 
 export function makeGetIsCurrentUserFileOwner(): (state: GlobalState, fileInfo: FileInfo) => boolean {
     return createSelector(
@@ -33,7 +33,7 @@ export function makeGetIsCurrentUserFileOwner(): (state: GlobalState, fileInfo: 
 
 export function makeGetCollaboraFilePermissions(): (state: GlobalState, fileInfo: FileInfo) => FILE_EDIT_PERMISSIONS {
     return createSelector(
-        (state: GlobalState) => collaboraFileEditPermissionsEnabled(state),
+        (state: GlobalState) => enableEditPermissions(state),
         (state: GlobalState, fileInfo: FileInfo) => getPost(state, fileInfo.post_id || ''),
         (state: GlobalState, fileInfo: FileInfo) => fileInfo.id,
         (featureEnabled, post, fileID) => {

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -1,14 +1,48 @@
-import {GlobalState} from 'mattermost-webapp/types/store';
+import {createSelector} from 'reselect';
 
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {FileInfo} from 'mattermost-redux/types/files';
+
+import {FILE_EDIT_PERMISSIONS} from '../constants';
 import {id as pluginId} from '../manifest';
 
 //@ts-ignore GlobalState is not complete
 const getPluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
-
-export const collaboraConfig = (state: GlobalState) => getPluginState(state).config;
 
 export const wopiFilesList = (state: GlobalState) => getPluginState(state).wopiFilesList;
 
 export const filePreviewModal = (state: GlobalState) => getPluginState(state).filePreviewModal;
 
 export const createFileModal = (state: GlobalState) => getPluginState(state).createFileModal;
+
+export const collaboraConfig = (state: GlobalState) => getPluginState(state).config;
+
+export const collaboraFileEditPermissionsEnabled = (state: GlobalState) => Boolean(collaboraConfig(state)?.file_edit_permissions);
+
+export function makeGetIsCurrentUserFileOwner(): (state: GlobalState, fileInfo: FileInfo) => boolean {
+    return createSelector(
+        (state: GlobalState, fileInfo: FileInfo) => getPost(state, fileInfo.post_id || ''),
+        (state: GlobalState) => getCurrentUser(state),
+        (post, currentUser) => {
+            return Boolean(post?.user_id === currentUser.id);
+        },
+    );
+}
+
+export function makeGetCollaboraFilePermissions(): (state: GlobalState, fileInfo: FileInfo) => FILE_EDIT_PERMISSIONS {
+    return createSelector(
+        (state: GlobalState) => collaboraFileEditPermissionsEnabled(state),
+        (state: GlobalState, fileInfo: FileInfo) => getPost(state, fileInfo.post_id || ''),
+        (state: GlobalState, fileInfo: FileInfo) => fileInfo.id,
+        (featureEnabled, post, fileID) => {
+            if (!featureEnabled) {
+                // if the feature id disabled, then everyone in the channel can edit
+                return FILE_EDIT_PERMISSIONS.PERMISSION_CHANNEL;
+            }
+
+            return post?.props?.[pluginId + '_file_permissions_' + fileID];
+        },
+    );
+}


### PR DESCRIPTION
#### Summary

- Add file edit permissions setting in system console.
- If the feature is enabled, then file can be edited by the owner by default and the owner can share the file with the entire channel.

#### Screenshots

![Peek 2021-06-24 20-10](https://user-images.githubusercontent.com/35728906/123283163-c1b1df80-d528-11eb-9090-77cb47af7d25.gif)
